### PR TITLE
[P3] cases-ui: CasePreviewPane region 표시 결함 fix

### DIFF
--- a/src/components/cases/CasePreviewPane.tsx
+++ b/src/components/cases/CasePreviewPane.tsx
@@ -1,4 +1,5 @@
 import type { EiaCase } from '@/lib/types/case-search';
+import { formatLocation } from '@/features/similar-cases/format-location';
 import { eiassProjectUrl } from '../../../packages/eia-data/src/deep-link';
 
 export default function CasePreviewPane({ eiaCase }: { eiaCase: EiaCase | null }) {
@@ -13,7 +14,7 @@ export default function CasePreviewPane({ eiaCase }: { eiaCase: EiaCase | null }
       <dl className="grid gap-1 text-small">
         <div>
           <dt className="inline text-text-secondary">위치: </dt>
-          <dd className="inline">{eiaCase.eia_addr_txt ?? '미상'}</dd>
+          <dd className="inline">{formatLocation(eiaCase)}</dd>
         </div>
         <div>
           <dt className="inline text-text-secondary">규모: </dt>

--- a/src/features/similar-cases/format-location.test.ts
+++ b/src/features/similar-cases/format-location.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { formatLocation } from './format-location';
+
+describe('formatLocation', () => {
+  it('returns "{sido} {sigungu}" when both populated (경상북도 영양군)', () => {
+    expect(formatLocation({ region_sido: '경상북도', region_sigungu: '영양군' })).toBe(
+      '경상북도 영양군'
+    );
+  });
+
+  it('returns "{sido} {sigungu}" for 강원도 강릉시', () => {
+    expect(formatLocation({ region_sido: '강원도', region_sigungu: '강릉시' })).toBe(
+      '강원도 강릉시'
+    );
+  });
+
+  it('returns sido only when sigungu is null (강원도)', () => {
+    expect(formatLocation({ region_sido: '강원도', region_sigungu: null })).toBe('강원도');
+  });
+
+  it('returns "지역 미상" when both null', () => {
+    expect(formatLocation({ region_sido: null, region_sigungu: null })).toBe('지역 미상');
+  });
+});

--- a/src/features/similar-cases/format-location.ts
+++ b/src/features/similar-cases/format-location.ts
@@ -1,0 +1,12 @@
+export function formatLocation(eiaCase: {
+  region_sido: string | null;
+  region_sigungu: string | null;
+}): string {
+  if (!eiaCase.region_sido) {
+    return '지역 미상';
+  }
+  if (eiaCase.region_sigungu) {
+    return `${eiaCase.region_sido} ${eiaCase.region_sigungu}`;
+  }
+  return eiaCase.region_sido;
+}

--- a/src/pages/cases/[caseId].astro
+++ b/src/pages/cases/[caseId].astro
@@ -1,5 +1,6 @@
 ---
 import AppLayout from '@/layouts/AppLayout.astro';
+import { formatLocation } from '@/features/similar-cases/format-location';
 import { eiassProjectUrl } from '../../../packages/eia-data/src/deep-link';
 
 const { caseId } = Astro.params;
@@ -36,7 +37,7 @@ if (!row) return new Response('not found', { status: 404 });
   <dl class="mt-4 grid gap-1 text-small">
     <div>
       <dt class="inline text-text-secondary">위치:</dt>
-      <dd class="inline">{row.eia_addr_txt ?? '미상'}</dd>
+      <dd class="inline">{formatLocation(row)}</dd>
     </div>
     <div>
       <dt class="inline text-text-secondary">평가단계:</dt>


### PR DESCRIPTION
## Summary

handover §3(c) 의 "[P3] CasePreviewPane region 표시 결함" 해소.

운영 D1 의 `eia_addr_txt` 가 10건 모두 NULL 인데 CasePreviewPane / 모바일 fallback 페이지가 `eia_addr_txt` 만 참조하여 카드 ↔ 패널 데이터 모순 ("경상북도 청송군" vs "위치: 미상").

## Changes

- `src/features/similar-cases/format-location.ts` 신규 — region_sido/sigungu fallback helper
- `src/features/similar-cases/format-location.test.ts` 신규 — 4 RED cases
- `CasePreviewPane.tsx` — eia_addr_txt 참조 → formatLocation()
- `[caseId].astro:39` (모바일 fallback) — 동일 patch

## Verification

- `npm test` — 320 PASS (regression 0, 새 4)
- typecheck PASS (better-sqlite3 §10.1 격리)
- ESLint / Prettier / assertion-grep clean

## Follow-up (P3, scope 외)

`[caseId].astro:32-35` 모바일 subtitle 의 leading " · " 결함 (region NULL 4건 시 cosmetic). 별도 hotfix.

## DoD

- [x] 카드 ↔ 패널 데이터 일관성
- [x] 320+ tests PASS
- [x] 운영 검증 (Phase 2)