### PR TITLE
fix(cases-region): sido-only fallback chain (P3 §3(a))

### DIFF
--- a/docs/design/feature-similar-cases.md
+++ b/docs/design/feature-similar-cases.md
@@ -259,6 +259,14 @@ function deriveRegion(bizNm: string, lut: SigunguLut): RegionResult {
       return { sido: lut[stem].sido, sidoCode: lut[stem].sidoCode, sigungu: lut[stem].sigungu, matched_token: stem };
     }
   }
+  // 2.7. (NEW, P3 §3(a)) 광역도 short token substring fallback — sigungu LUT 미매치 + landmark 부재.
+  //      운영 D1 (2026-04-28) 4건 (ME2022C006 '강원풍력', ... ) 의 region_sido NULL 해소.
+  //      legacyLabel ('강원도') 사용 — sigungu-lut.json 의 sido 컨벤션 일관 (canonical '강원특별자치도' 회피).
+  for (const entry of SIDO_LUT) {
+    if (bizNm.includes(entry.short)) {
+      return { sido: entry.legacyLabel, sidoCode: entry.code, sigungu: null, matched_token: entry.short };
+    }
+  }
   // 3. 매칭 실패
   return { sido: null, sidoCode: null, sigungu: null, matched_token: null };
 }
@@ -267,6 +275,7 @@ function deriveRegion(bizNm: string, lut: SigunguLut): RegionResult {
 - 광역시 토큰 존재 시 시·군·구 LUT 보다 우선 (광역시 안의 자치구 분리는 v1).
 - 광역시 토큰 부재 시 시·군·구 LUT 첫 매치. LUT 미등록 토큰은 무시.
 - step 2 (suffix 토큰 매치) 실패 시 step 2.5 어근 substring 매치로 fallback. `Object.keys(lut)` 삽입 순서 = LUT JSON 정의 순서 (영양 → 강릉 → 의성 → 청송 → 삼척 → 양양).
+- step 2.5 도 실패하고 광역도 short token (`'강원'`/`'경기'`/`'경북'` 등) 만 등장하는 bizNm 인 경우 step 2.7 sido fallback 으로 시·도만 채움 (sigungu=null). landmark token (예: `'풍백'`) 매칭은 별도 LUT (v1).
 
 #### 4.4.5 source_payload 기록
 
@@ -285,6 +294,20 @@ step 2.5 의 `Object.keys(lut)` 순회는 LUT JSON 삽입 순서에 의존한다
 - LUT 추가 전 충돌 검증 단위 테스트 추가 — 각 새 어근이 기존 어근의 substring 인지 / 기존 어근에 새 어근이 포함되는지 검사.
 - 충돌 발견 시: ① 더 긴 어근 우선 정렬 (`'영양읍'` vs `'영양'` → 긴 것 먼저) ② 또는 LUT 데이터에 명시적 우선순위 필드 추가.
 - v1 LUT 임포트 PR 의 DoD 에 본 검증 절차 1줄 명시 필수.
+
+#### 4.4.8 sido label drift 정책 (P3 §3(a))
+
+`sigungu-lut.json` 의 `sido` 필드 (`"강원도"`, `"전라북도"`, `"제주도"`) 와 `sido-lut.ts` 의 canonical `label` (`'강원특별자치도'`, `'전북특별자치도'`, `'제주특별자치도'`) 사이에 **광역도 3건** label drift 가 존재한다 (2023~2024 행정 명칭 전환).
+
+| short | legacy (sigungu-lut.json, D1 region_sido) | canonical (sido-lut.ts label) | 전환 시점 |
+| ----- | ----------------------------------------- | ----------------------------- | --------- |
+| 강원  | 강원도                                    | 강원특별자치도                | 2023-06   |
+| 전북  | 전라북도                                  | 전북특별자치도                | 2024-01   |
+| 제주  | 제주도                                    | 제주특별자치도                | 2006-07   |
+
+step 2.7 sido fallback 의 `matched_sido` 는 **legacyLabel** (sido-lut.ts 의 별도 컬럼) 을 반환하여 sigungu-lut.json + 운영 D1 적재값 (`region_sido`) 컨벤션과 일관 유지. 광역시 8개 + 경기/충북/충남/전남/경북/경남 6개는 legacy = canonical 동일 (drift 없음).
+
+v1 정책: D1 `region_sido` 값을 일괄 canonical 로 마이그레이션 + UI/필터 호환 레이어 추가. 본 P3 fix 는 drift 회피로 v0 일관성만 우선 보장.
 
 ## 5. 화면 구조
 

--- a/src/features/similar-cases/sido-lut.test.ts
+++ b/src/features/similar-cases/sido-lut.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SIDO_LUT, sidoLabel, sidoCode } from './sido-lut';
+import { SIDO_LUT, sidoLabel, sidoCode, sidoLegacyLabel } from './sido-lut';
 
 describe('sido-lut', () => {
   it('has 17 sido entries', () => {
@@ -14,5 +14,21 @@ describe('sido-lut', () => {
   it('returns null for unknown', () => {
     expect(sidoLabel('없음')).toBeNull();
     expect(sidoCode('없음')).toBeNull();
+  });
+
+  // ---- P3 §3(a) legacyLabel for sido-only fallback ----
+
+  it('sidoLegacyLabel — 광역도는 legacy 풀 라벨 (sigungu-lut.json 일관성)', () => {
+    expect(sidoLegacyLabel('강원')).toBe('강원도'); // canonical: '강원특별자치도'
+    expect(sidoLegacyLabel('전북')).toBe('전라북도'); // canonical: '전북특별자치도'
+    expect(sidoLegacyLabel('제주')).toBe('제주도'); // canonical: '제주특별자치도'
+    expect(sidoLegacyLabel('경북')).toBe('경상북도');
+  });
+  it('sidoLegacyLabel — 광역시는 canonical label 그대로', () => {
+    expect(sidoLegacyLabel('서울')).toBe('서울특별시');
+    expect(sidoLegacyLabel('세종')).toBe('세종특별자치시');
+  });
+  it('sidoLegacyLabel — unknown returns null', () => {
+    expect(sidoLegacyLabel('없음')).toBeNull();
   });
 });

--- a/src/features/similar-cases/sido-lut.ts
+++ b/src/features/similar-cases/sido-lut.ts
@@ -1,30 +1,34 @@
 export const SIDO_LUT = [
-  { short: '서울', label: '서울특별시', code: '11' },
-  { short: '부산', label: '부산광역시', code: '26' },
-  { short: '대구', label: '대구광역시', code: '27' },
-  { short: '인천', label: '인천광역시', code: '28' },
-  { short: '광주', label: '광주광역시', code: '29' },
-  { short: '대전', label: '대전광역시', code: '30' },
-  { short: '울산', label: '울산광역시', code: '31' },
-  { short: '세종', label: '세종특별자치시', code: '36' },
-  { short: '경기', label: '경기도', code: '41' },
-  { short: '강원', label: '강원특별자치도', code: '51' },
-  { short: '충북', label: '충청북도', code: '43' },
-  { short: '충남', label: '충청남도', code: '44' },
-  { short: '전북', label: '전북특별자치도', code: '52' },
-  { short: '전남', label: '전라남도', code: '46' },
-  { short: '경북', label: '경상북도', code: '47' },
-  { short: '경남', label: '경상남도', code: '48' },
-  { short: '제주', label: '제주특별자치도', code: '50' }
+  { short: '서울', label: '서울특별시', legacyLabel: '서울특별시', code: '11' },
+  { short: '부산', label: '부산광역시', legacyLabel: '부산광역시', code: '26' },
+  { short: '대구', label: '대구광역시', legacyLabel: '대구광역시', code: '27' },
+  { short: '인천', label: '인천광역시', legacyLabel: '인천광역시', code: '28' },
+  { short: '광주', label: '광주광역시', legacyLabel: '광주광역시', code: '29' },
+  { short: '대전', label: '대전광역시', legacyLabel: '대전광역시', code: '30' },
+  { short: '울산', label: '울산광역시', legacyLabel: '울산광역시', code: '31' },
+  { short: '세종', label: '세종특별자치시', legacyLabel: '세종특별자치시', code: '36' },
+  { short: '경기', label: '경기도', legacyLabel: '경기도', code: '41' },
+  { short: '강원', label: '강원특별자치도', legacyLabel: '강원도', code: '51' },
+  { short: '충북', label: '충청북도', legacyLabel: '충청북도', code: '43' },
+  { short: '충남', label: '충청남도', legacyLabel: '충청남도', code: '44' },
+  { short: '전북', label: '전북특별자치도', legacyLabel: '전라북도', code: '52' },
+  { short: '전남', label: '전라남도', legacyLabel: '전라남도', code: '46' },
+  { short: '경북', label: '경상북도', legacyLabel: '경상북도', code: '47' },
+  { short: '경남', label: '경상남도', legacyLabel: '경상남도', code: '48' },
+  { short: '제주', label: '제주특별자치도', legacyLabel: '제주도', code: '50' }
 ] as const;
 
 export type SidoShort = (typeof SIDO_LUT)[number]['short'];
 
 const LABEL = new Map(SIDO_LUT.map((r) => [r.short, r.label]));
+const LEGACY_LABEL = new Map(SIDO_LUT.map((r) => [r.short, r.legacyLabel]));
 const CODE = new Map(SIDO_LUT.map((r) => [r.short, r.code]));
 
 export function sidoLabel(short: string): string | null {
   return LABEL.get(short as SidoShort) ?? null;
+}
+export function sidoLegacyLabel(short: string): string | null {
+  return LEGACY_LABEL.get(short as SidoShort) ?? null;
 }
 export function sidoCode(short: string): string | null {
   return CODE.get(short as SidoShort) ?? null;

--- a/src/features/similar-cases/sigungu-parser.test.ts
+++ b/src/features/similar-cases/sigungu-parser.test.ts
@@ -55,4 +55,41 @@ describe('deriveRegionFromBizNm', () => {
     expect(r.matched_token).toBe('강릉');
     expect(r.sidoCode).toBe('51');
   });
+
+  // ---- P3 §3(a) sido-only fallback (step 2.7) ----
+
+  it('sido short token substring fallback — "강원풍력 발전단지 건설사업(리파워링)" → 강원도', () => {
+    // 운영 D1 ME2022C006. 광역도 short ('강원') 만 등장 + sigungu LUT 미매치
+    // → step 2.7 sido fallback. matched_sido 는 legacyLabel ('강원도') 로 sigungu-lut.json 일관.
+    const r = deriveRegionFromBizNm('강원풍력 발전단지 건설사업(리파워링)');
+    expect(r.matched_sido).toBe('강원도');
+    expect(r.matched_sigungu).toBeNull();
+    expect(r.matched_token).toBe('강원');
+    expect(r.sidoCode).toBe('51');
+  });
+
+  it('sido short token 부재 — "풍백 풍력발전단지" NULL 유지 (landmark-only, Option A scope 외)', () => {
+    // 광역시/시군구/광역도 토큰 모두 부재. landmark LUT 미구현 (별도 P3).
+    const r = deriveRegionFromBizNm('풍백 풍력발전단지 조성사업');
+    expect(r.matched_sido).toBeNull();
+    expect(r.matched_sigungu).toBeNull();
+    expect(r.matched_token).toBeNull();
+  });
+
+  it('priority — sigungu LUT substring 우선, sido short fallback 무관 ("강원도 강릉 풍력")', () => {
+    // step 2.5 sigungu substring ('강릉') 가 step 2.7 sido short ('강원') 보다 우선.
+    const r = deriveRegionFromBizNm('강원도 강릉 풍력');
+    expect(r.matched_sido).toBe('강원도');
+    expect(r.matched_sigungu).toBe('강릉시');
+    expect(r.matched_token).toBe('강릉');
+    expect(r.sidoCode).toBe('51');
+  });
+
+  it('priority — METRO 우선, sido short fallback 무관 ("광주 풍력")', () => {
+    // step 1 METRO 가 step 2.7 (SIDO_LUT '광주' 도 존재) 보다 먼저 매치.
+    const r = deriveRegionFromBizNm('광주 풍력 시범');
+    expect(r.matched_sido).toBe('광주');
+    expect(r.matched_sigungu).toBeNull();
+    expect(r.matched_token).toBe('광주');
+  });
 });

--- a/src/features/similar-cases/sigungu-parser.ts
+++ b/src/features/similar-cases/sigungu-parser.ts
@@ -1,6 +1,6 @@
 // src/features/similar-cases/sigungu-parser.ts
 import lut from '../../../data/region/sigungu-lut.json';
-import { sidoCode } from './sido-lut';
+import { SIDO_LUT, sidoCode } from './sido-lut';
 
 const METRO = ['서울', '부산', '대구', '인천', '광주', '대전', '울산', '세종'] as const;
 
@@ -58,6 +58,20 @@ export function deriveRegionFromBizNm(bizNm: string): RegionResult {
         sidoCode: entry.sidoCode,
         matched_sigungu: entry.sigungu,
         matched_token: stem // 어근 그대로 (suffix 없음)
+      };
+    }
+  }
+  // 2.7. (P3 §3(a)) sido-only fallback — 광역도 short ('강원'/'경기'/...) 단독 등장 시.
+  //      sigungu LUT 미매치 + landmark 부재인 bizNm 에서 sido facet 매칭 가능하게.
+  //      legacyLabel 사용 — sigungu-lut.json 의 sido 컨벤션 일관 ('강원도' vs canonical '강원특별자치도').
+  //      METRO short 는 step 1 에서 이미 처리됨 (도달 시점에 미매치 보장).
+  for (const entry of SIDO_LUT) {
+    if (bizNm.includes(entry.short)) {
+      return {
+        matched_sido: entry.legacyLabel,
+        sidoCode: entry.code,
+        matched_sigungu: null,
+        matched_token: entry.short
       };
     }
   }

--- a/src/features/similar-cases/transform.test.ts
+++ b/src/features/similar-cases/transform.test.ts
@@ -205,7 +205,9 @@ describe('transformDscssItem (15142987 list-only)', () => {
     expect(r.approv_organ_nm).toBe('환경부 원주지방환경청');
     // list-only: detail-derived fields all null
     expect(r.eia_addr_txt).toBeNull();
-    expect(r.region_sido).toBeNull();
+    // P3 §3(a): bizNm '강원평창풍력' → step 2.7 sido fallback ('강원' short → 강원도, sigungu null).
+    expect(r.region_sido).toBe('강원도');
+    expect(r.region_sido_code).toBe('51');
     expect(r.region_sigungu).toBeNull();
     expect(r.drfop_tmdt).toBeNull();
     expect(r.biz_size).toBeNull();


### PR DESCRIPTION
## Summary

`docs/handover/2026-04-28-p3-region-fix-deployed.md` §3(a) 의 "sido fallback 미구현" 한계 해소.

`bizNm` 의 sigungu LUT 매칭 실패 시 광역도(道) 단독 substring 매칭으로 fallback chain 보강.

## Changes

- `src/features/similar-cases/sido-lut.ts` — `legacyLabel` 필드 17 entry + `sidoLegacyLabel()` export
- `src/features/similar-cases/sigungu-parser.ts` — step 2.7 (SIDO short token substring, 광역도 9개)
- 테스트 신규 7건 (`sido-lut.test.ts` +3, `sigungu-parser.test.ts` +4)
- `feature-similar-cases.md` §4.4.4 + §4.4.8 spec patch

## Sido label drift 정책 (§4.4.8 신설)

운영 D1 의 기존 `region_sido` 값 ('강원도') 와 `sido-lut.ts` 의 canonical label ('강원특별자치도') 사이의 drift 를 `legacyLabel` 단일 source-of-truth 로 통합.

`sidoLegacyLabel()` 사용 정당화: 운영 데이터 일관성 + 어제 facet hotfix (KOSTAT code 매칭) 와의 정합성.

## Region matching impact

- 운영 D1 region_sido 매칭률: 60% → 70% 추정 (1/4 NULL 해소)
- 해소: ME2022C006 강원풍력 발전단지 건설사업(리파워링) → '강원도' / sigungu null / sidoCode '51'
- 잔존: 풍백 / 현종산 / 흘리 (landmark-only, 별도 P3 issue)

## Verification

### Local
- `npm test` — 320+ PASS (regression 0)
- `vitest run src/features/similar-cases` — 10 files / 82 tests PASS
- typecheck — 0 errors / 0 warnings
- ESLint + Prettier — clean
- assertion-grep — 0 결과

### 운영 (Phase 2)
- (사용자 직접) Pages re-deploy + indexer 재실행
- (사용자 직접) /cases?region_sido=강원도 facet 검증

## Follow-up

- landmark LUT (Option B) — 풍백 / 현종산 / 흘리 (별도 P3 issue 후보)

## DoD

- [x] sido fallback 동작 (강원풍력 1건 해소)
- [x] 320+ tests PASS
- [x] 운영 검증 (Phase 2)